### PR TITLE
Fixes #13: correct input file for join_data.R

### DIFF
--- a/src/join_data.R
+++ b/src/join_data.R
@@ -3,7 +3,7 @@
 options(stringsAsFactors=F)
 
 # load what we've extracted from the XML so far
-xml_extract = read.table('clinvar_table_dedup_normalized.tsv',sep='\t',comment.char='',quote='',header=T)
+xml_extract = read.table('clinvar_table_normalized.tsv',sep='\t',comment.char='',quote='',header=T)
 
 # load the tab-delimited summary
 txt_download = read.table('variant_summary.txt.gz',sep='\t',comment.char='',quote='',header=T)


### PR DESCRIPTION
The input file of `join_data.R` should be `clinvar_table_normalized.tsv`, otherwise the script fails with an error.
